### PR TITLE
Added VPC endpoints for DynamoDB and S3

### DIFF
--- a/server/aws/vpc.yaml
+++ b/server/aws/vpc.yaml
@@ -174,6 +174,22 @@ Resources:
           Value: !Join ['-', [!Ref 'AWS::StackName', temp]]
       VpcId: !Ref 'VPC'
 
+  DDBVPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref 'VPC'
+      RouteTableIds:
+        - !Ref 'RouteTable'
+      ServiceName: com.amazonaws.us-east-1.dynamodb
+
+  S3VPCEndpoint:
+    Type: AWS::EC2::VPCEndpoint
+    Properties:
+      VpcId: !Ref 'VPC'
+      RouteTableIds:
+        - !Ref 'RouteTable'
+      ServiceName: com.amazonaws.us-east-1.s3
+
 
 Outputs:
   StackName:


### PR DESCRIPTION
This is a fix for the lambda functions in the SDP to be able to access DynamoDB and S3 when they are deployed inside the VPC.

The vpc.yaml file is currently in this repo, but it could easily live inside the SDP repo. All of our infrastructure will use it, so I have no preference really.